### PR TITLE
Fixed device name

### DIFF
--- a/efistub
+++ b/efistub
@@ -40,7 +40,7 @@ fn_add_bootentry() {
 
   local EFIDEVICE=$(blkid -U $EFI_UUID)
   local EFIPART=${EFIDEVICE:(-1)}
-  local EFIDISK=${EFIDEVICE%$EFIPART}
+  local EFIDISK="$(lsblk -npo pkname ${EFIDEVICE})"
 
   # create EFI boot menu entry
   if [[ -z $BOOTOPT ]]; then


### PR DESCRIPTION
Script fails for nvme-disk partitions because removing "partition id" is not sufficient to find out its disk name.
Example: nvme disk in Lenovo T490 is presented as /dev/nvme0n1 and partition is /dev/nvme0n1**p1**

Partial output from script:
```
++ blkid -s UUID -o value /dev/nvme0n1p1
+ local EFI_UUID=125C-4E93
++ blkid -U 125C-4E93
+ local EFIDEVICE=/dev/nvme0n1p1
+ local EFIPART=1
+ local EFIDISK=/dev/nvme0n1p
```

Replacing EFIDISK resolution with lsblk command properly resolved devices I test.